### PR TITLE
Accelerate with copilot

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = .
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest

--- a/src/app.py
+++ b/src/app.py
@@ -7,7 +7,7 @@ for extracurricular activities at Mergington High School.
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, JSONResponse
 import os
 from pathlib import Path
 
@@ -88,7 +88,7 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return JSONResponse(content=activities, headers={"Cache-Control": "no-store"})
 
 
 @app.post("/activities/{activity_name}/signup")
@@ -108,3 +108,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/signup")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Validate student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Student is not signed up for this activity")
+
+    # Remove all registrations for this email in case duplicates exist
+    activity["participants"] = [participant for participant in activity["participants"] if participant != email]
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse, JSONResponse
 import os
 from pathlib import Path
+from pydantic import EmailStr
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -92,7 +93,7 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: EmailStr):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +112,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/signup")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: EmailStr):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports related activities
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": ["alex@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly games",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["mia@mergington.edu", "noah@mergington.edu"]
+    },
+    # Artistic activities
+    "Drama Club": {
+        "description": "Act, direct, and participate in school plays",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ava@mergington.edu", "liam@mergington.edu"]
+    },
+    "Art Workshop": {
+        "description": "Explore painting, drawing, and sculpture",
+        "schedule": "Fridays, 2:00 PM - 3:30 PM",
+        "max_participants": 16,
+        "participants": ["ella@mergington.edu", "jack@mergington.edu"]
+    },
+    # Intellectual activities
+    "Math Club": {
+        "description": "Solve challenging math problems and prepare for competitions",
+        "schedule": "Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 14,
+        "participants": ["grace@mergington.edu", "henry@mergington.edu"]
+    },
+    "Science Olympiad": {
+        "description": "Participate in science events and experiments",
+        "schedule": "Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["chloe@mergington.edu", "ben@mergington.edu"]
     }
 }
 
@@ -61,6 +100,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -21,39 +21,84 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
         const participants = details.participants || [];
-        const participantItems = participants.length
-          ? participants
-              .map(
-                (email) => `
-              <li class="participant-item">
-                <span class="participant-email">${email}</span>
-                <button
-                  type="button"
-                  class="remove-participant-btn"
-                  data-activity="${name}"
-                  data-email="${email}"
-                  title="Unregister ${email}"
-                  aria-label="Unregister ${email} from ${name}"
-                >
-                  &times;
-                </button>
-              </li>`
-              )
-              .join("")
-          : '<li class="no-participants">No participants yet</li>';
 
-        activityCard.innerHTML = `
-          <h4>${name}</h4>
-          <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
-          <div class="participants-section">
-            <p class="participants-title"><strong>Participants (${participants.length}/${details.max_participants})</strong></p>
-            <ul class="participants-list">
-              ${participantItems}
-            </ul>
-          </div>
-        `;
+        // Title
+        const titleEl = document.createElement("h4");
+        titleEl.textContent = name;
+        activityCard.appendChild(titleEl);
+
+        // Description
+        const descriptionEl = document.createElement("p");
+        descriptionEl.textContent = details.description;
+        activityCard.appendChild(descriptionEl);
+
+        // Schedule
+        const scheduleEl = document.createElement("p");
+        const scheduleStrong = document.createElement("strong");
+        scheduleStrong.textContent = "Schedule:";
+        scheduleEl.appendChild(scheduleStrong);
+        scheduleEl.appendChild(document.createTextNode(" " + details.schedule));
+        activityCard.appendChild(scheduleEl);
+
+        // Availability
+        const availabilityEl = document.createElement("p");
+        const availabilityStrong = document.createElement("strong");
+        availabilityStrong.textContent = "Availability:";
+        availabilityEl.appendChild(availabilityStrong);
+        availabilityEl.appendChild(
+          document.createTextNode(" " + spotsLeft + " spots left")
+        );
+        activityCard.appendChild(availabilityEl);
+
+        // Participants section
+        const participantsSection = document.createElement("div");
+        participantsSection.className = "participants-section";
+
+        const participantsTitle = document.createElement("p");
+        participantsTitle.className = "participants-title";
+        const participantsTitleStrong = document.createElement("strong");
+        participantsTitleStrong.textContent =
+          "Participants (" + participants.length + "/" + details.max_participants + ")";
+        participantsTitle.appendChild(participantsTitleStrong);
+        participantsSection.appendChild(participantsTitle);
+
+        const participantsList = document.createElement("ul");
+        participantsList.className = "participants-list";
+
+        if (!participants.length) {
+          const noParticipantsItem = document.createElement("li");
+          noParticipantsItem.className = "no-participants";
+          noParticipantsItem.textContent = "No participants yet";
+          participantsList.appendChild(noParticipantsItem);
+        } else {
+          participants.forEach((email) => {
+            const li = document.createElement("li");
+            li.className = "participant-item";
+
+            const emailSpan = document.createElement("span");
+            emailSpan.className = "participant-email";
+            emailSpan.textContent = email;
+            li.appendChild(emailSpan);
+
+            const removeButton = document.createElement("button");
+            removeButton.type = "button";
+            removeButton.className = "remove-participant-btn";
+            removeButton.setAttribute("data-activity", name);
+            removeButton.setAttribute("data-email", email);
+            removeButton.setAttribute("title", "Unregister " + email);
+            removeButton.setAttribute(
+              "aria-label",
+              "Unregister " + email + " from " + name
+            );
+            removeButton.textContent = "×";
+
+            li.appendChild(removeButton);
+            participantsList.appendChild(li);
+          });
+        }
+
+        participantsSection.appendChild(participantsList);
+        activityCard.appendChild(participantsSection);
 
         activitiesList.appendChild(activityCard);
 

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -7,11 +7,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", { cache: "no-store" });
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -19,12 +20,39 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participants = details.participants || [];
+        const participantItems = participants.length
+          ? participants
+              .map(
+                (email) => `
+              <li class="participant-item">
+                <span class="participant-email">${email}</span>
+                <button
+                  type="button"
+                  class="remove-participant-btn"
+                  data-activity="${name}"
+                  data-email="${email}"
+                  title="Unregister ${email}"
+                  aria-label="Unregister ${email} from ${name}"
+                >
+                  &times;
+                </button>
+              </li>`
+              )
+              .join("")
+          : '<li class="no-participants">No participants yet</li>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <p class="participants-title"><strong>Participants (${participants.length}/${details.max_participants})</strong></p>
+            <ul class="participants-list">
+              ${participantItems}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +90,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +107,52 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  // Handle unregistering participants from activity cards
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".remove-participant-btn");
+    if (!removeButton) {
+      return;
+    }
+
+    const activity = removeButton.dataset.activity;
+    const email = removeButton.dataset.email;
+
+    if (!activity || !email) {
+      return;
+    }
+
+    removeButton.disabled = true;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodeURIComponent(activity)}/signup?email=${encodeURIComponent(email)}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      console.error("Error unregistering participant:", error);
+    } finally {
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
     }
   });
 

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -170,6 +170,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     removeButton.disabled = true;
+    let shouldReenableButton = true;
 
     try {
       const response = await fetch(
@@ -185,6 +186,9 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         await fetchActivities();
+        // The activities list has been refreshed, so the original button
+        // is no longer part of the active UI and does not need re-enabling.
+        shouldReenableButton = false;
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -198,6 +202,9 @@ document.addEventListener("DOMContentLoaded", () => {
       setTimeout(() => {
         messageDiv.classList.add("hidden");
       }, 5000);
+      if (shouldReenableButton) {
+        removeButton.disabled = false;
+      }
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,83 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #d5def4;
+  background: linear-gradient(135deg, #eef3ff, #f9fbff);
+}
+
+.participants-title {
+  margin-bottom: 8px;
+  color: #1a237e;
+  font-size: 0.95rem;
+}
+
+.participants-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 4px;
+}
+
+.participants-list li {
+  color: #2f3f67;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: #ffffff;
+  border: 1px solid #e1e7f8;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.remove-participant-btn {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid #ef9a9a;
+  background-color: #ffebee;
+  color: #b71c1c;
+  font-size: 20px;
+  line-height: 1;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.remove-participant-btn:hover {
+  background-color: #ffcdd2;
+  border-color: #e57373;
+  color: #8e0000;
+}
+
+.remove-participant-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.participants-list .no-participants {
+  font-style: italic;
+  color: #6b7897;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+_BASELINE_ACTIVITIES = copy.deepcopy(app_module.activities)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    app_module.activities.clear()
+    app_module.activities.update(copy.deepcopy(_BASELINE_ACTIVITIES))
+    yield
+    app_module.activities.clear()
+    app_module.activities.update(copy.deepcopy(_BASELINE_ACTIVITIES))
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,41 @@
+import src.app as app_module
+
+
+def test_signup_adds_new_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+    assert email in app_module.activities[activity_name]["participants"]
+
+
+def test_signup_rejects_duplicate_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "michael@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Student already signed up"}
+
+
+def test_signup_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "new.student@mergington.edu"
+
+    # Act
+    response = client.post(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,57 @@
+import src.app as app_module
+
+
+def test_unregister_removes_existing_participant(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "temporary.student@mergington.edu"
+    app_module.activities[activity_name]["participants"].append(email)
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Unregistered {email} from {activity_name}"}
+    assert email not in app_module.activities[activity_name]["participants"]
+
+
+def test_unregister_returns_not_found_for_unknown_activity(client):
+    # Arrange
+    activity_name = "Unknown Activity"
+    email = "temporary.student@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}
+
+
+def test_unregister_returns_not_found_for_non_member(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "not.registered@mergington.edu"
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Student is not signed up for this activity"}
+
+
+def test_unregister_removes_all_duplicate_entries_for_email(client):
+    # Arrange
+    activity_name = "Chess Club"
+    email = "duplicate.student@mergington.edu"
+    app_module.activities[activity_name]["participants"].extend([email, email])
+
+    # Act
+    response = client.delete(f"/activities/{activity_name}/signup", params={"email": email})
+
+    # Assert
+    assert response.status_code == 200
+    remaining = app_module.activities[activity_name]["participants"]
+    assert email not in remaining


### PR DESCRIPTION
This pull request introduces several enhancements to the school activities management app, focusing on participant management, improved API responses, and expanded testing. The most important changes are grouped below by theme.

**Backend functionality enhancements:**

* Added support for unregistering a participant from an activity via a new `DELETE /activities/{activity_name}/signup` endpoint, including validation for activity existence and participant membership, and removal of duplicate registrations. (`src/app.py`)
* Expanded the activities data with new sports, artistic, and intellectual clubs, each with descriptions, schedules, and participant lists. (`src/app.py`)
* Improved the `GET /activities` endpoint to return a `JSONResponse` with a `Cache-Control: no-store` header, ensuring clients always receive fresh data. (`src/app.py`)

**Frontend improvements:**

* Updated the UI to display participants for each activity, including a styled participant list and a button to unregister participants directly from the activity card. (`src/static/app.js`, `src/static/styles.css`) [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R113-R158) [[3]](diffhunk://#diff-090bb81494e72cfcac6b0a6065f88e9caf9d80c00b887e38f02a690dbec0f8b2R77-R153)
* Ensured the frontend fetches activities with `cache: "no-store"` and refreshes the activity list after signups or unregistrations for real-time updates. (`src/static/app.js`) [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3L10-R55) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R93)

**Testing improvements:**

* Added comprehensive tests for participant signup and unregister functionality, including validation for duplicate signups, unknown activities, and removal of all duplicate participant entries. (`tests/test_signup.py`, `tests/test_unregister.py`) [[1]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R41) [[2]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R57)
* Introduced a fixture to reset the activities state before and after each test, ensuring test isolation and reliability. (`tests/conftest.py`)
* Configured pytest to use the `tests` directory for test discovery. (`pytest.ini`)